### PR TITLE
Open brower with encoded query

### DIFF
--- a/src/search_notes.tsx
+++ b/src/search_notes.tsx
@@ -109,7 +109,7 @@ export default function main() {
               actions={
                 <ActionPanel>
                   <ActionPanel.Section>
-                    <Action.OpenInBrowser url={`${kibelaGql.url}?query=${searchText}`} />
+                    <Action.OpenInBrowser url={`${kibelaGql.url}?query=${encodeURIComponent(searchText)}`} />
                   </ActionPanel.Section>
                 </ActionPanel>
               }


### PR DESCRIPTION
Hi 👋 @shimewtr 

I fixed a problem that it fails when I enter the query with Japanese 😉 

- [x] It can open the browser with multibyte query "エンジニア"
- [x] It can open the browser without multibyte query "Engineer"